### PR TITLE
Fix for double click bug on Anki 2.0

### DIFF
--- a/touchscreen/__init__.py
+++ b/touchscreen/__init__.py
@@ -327,6 +327,7 @@ function update_pen_settings(){
 
 canvas.addEventListener("mousedown",function (e) {
     isMouseDown = true;
+    event.preventDefault();
     arrays_of_points.push(new Array());
     arrays_of_points[arrays_of_points.length-1].push({ x: e.offsetX, y: e.offsetY });
     update_pen_settings()


### PR DESCRIPTION
On Anki 2.0 double clicks make the addon behave as if the primary mouse button is constantly held down. The only way to return to normal behavior is to click the X button on the touchscreen menu. This fixes that issue.
I tested it on both Anki 2.1 and 2.0, so there should be no regressions.