### PR TITLE
Increased drawing resolution for scaled screens

### DIFF
--- a/touchscreen/__init__.py
+++ b/touchscreen/__init__.py
@@ -314,6 +314,19 @@ function resize() {
 
     canvas.style.height = ctx.canvas.height + 'px';
     wrapper.style.width = ctx.canvas.width + 'px';
+    
+    /* Get DPR with 1 as fallback */
+    var dpr = window.devicePixelRatio || 1;
+    
+    /* CSS size is the same */
+    canvas.style.height = ctx.canvas.height + 'px';
+    wrapper.style.width = ctx.canvas.width + 'px';
+    
+    /* Increase DOM size and scale */
+    ctx.canvas.width *= dpr;
+    ctx.canvas.height *= dpr;
+    ctx.scale(dpr, dpr);
+    
     update_pen_settings()
 }
 


### PR DESCRIPTION
Scales canvas with screen scaling. 

Comparison with 150% scaling:
Before:
<img width="110" alt="Annotation 2019-11-02 204718" src="https://user-images.githubusercontent.com/10160023/68076356-d66dbc80-fdb3-11e9-8d7e-0d7c721f38f4.png">
After:
<img width="140" alt="Annotation 2019-11-02 204719" src="https://user-images.githubusercontent.com/10160023/68076357-d968ad00-fdb3-11e9-9a4b-2b6ea060444d.png">

